### PR TITLE
Basic server

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "react-scripts": "0.8.5"
   },
   "dependencies": {
+    "express": "^4.14.1",
+    "morgan": "^1.8.1",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-router": "^3.0.2"
@@ -14,6 +16,7 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "start:prod": "node server.js"
   }
 }

--- a/server.js
+++ b/server.js
@@ -6,9 +6,10 @@ const morgan = require('morgan');
 const path = require('path');
 
 app.use(morgan('dev'));
+app.use(express.static('./build'));
 
-app.get('/*', (req, res) => res.sendFile(path.join(__dirname, 'build', 'index.html')));
+app.get('*', (req, res) => res.sendFile(path.join(__dirname, 'build', 'index.html')));
 
-const listener = app.listen(process.env.PORT, () => {
+const listener = app.listen(3000, () => {
   console.log(`now listening on ${listener.address().port}`)
 });

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const app = express();
 const morgan = require('morgan');
 const path = require('path');
 
-app.use(morgan('dev'));
+app.use(morgan('common'));
 app.use(express.static('./build'));
 
 app.get('*', (req, res) => res.sendFile(path.join(__dirname, 'build', 'index.html')));

--- a/server.js
+++ b/server.js
@@ -10,6 +10,6 @@ app.use(express.static('./build'));
 
 app.get('*', (req, res) => res.sendFile(path.join(__dirname, 'build', 'index.html')));
 
-const listener = app.listen(3000, () => {
+const listener = app.listen(process.env.PORT || 3000, () => {
   console.log(`now listening on ${listener.address().port}`)
 });

--- a/server.js
+++ b/server.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const express = require('express');
+const app = express();
+const morgan = require('morgan');
+const path = require('path');
+
+app.use(morgan('dev'));
+
+app.get('/*', (req, res) => res.sendFile(path.join(__dirname, 'build', 'index.html')));
+
+const listener = app.listen(process.env.PORT, () => {
+  console.log(`now listening on ${listener.address().port}`)
+});


### PR DESCRIPTION
Sets up a bare-bones Express server with Morgan routing to serve my React-Router app. This will be handy if/when I want to get a blog up and running with like Ghost or something. 

From a wildcard route, serves assets at `./build`. The pre-defined React build script I've got will do this for me, but I should remember this in case I unpack the setup from create-react-app.